### PR TITLE
Integrate OpenTargets service with query and history endpoints

### DIFF
--- a/src/geneva/main.py
+++ b/src/geneva/main.py
@@ -3,15 +3,26 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .model import create_tables
-from .model import create_user as save_user
-from .model import get_user_by_name as get_user
+from .model import (
+    create_tables,
+    create_user,
+    get_user_by_name,
+    get_user_queries,
+    save_user_query,
+)
+from .services.opentarget import OpenTargetService
 from .utils import error, success
 
 
 class LoginRequest(BaseModel):
     username: str
     api_key: str | None = None
+
+
+class GeneDiseaseRequest(BaseModel):
+    username: str
+    gene: str
+    disease: str
 
 
 @asynccontextmanager
@@ -30,12 +41,12 @@ async def root():
 
 @app.post("/login")
 def login(request: LoginRequest):
-    user = get_user(request.username)
+    user = get_user_by_name(request.username)
 
     if request.api_key:
         if user:
             return error("Username already taken", status_code=409)
-        save_user(request.username, request.api_key)
+        create_user(request.username, request.api_key)
         return success(
             "User registered and logged in", {"username": request.username}
         )
@@ -47,10 +58,59 @@ def login(request: LoginRequest):
 
 @app.get("/user/{username}")
 def get_user_info(username: str):
-    user = get_user(username)
+    user = get_user_by_name(username)
     if not user:
         return error("User not found", status_code=404)
     return success(
         "User info retrieved",
         {"username": user.username, "has_api_key": bool(user.api_key)},
+    )
+
+
+@app.post("/query")
+def run_gene_disease_query(request: GeneDiseaseRequest):
+    user = get_user_by_name(request.username)
+    if not user:
+        return error("User not found", status_code=404)
+    service = OpenTargetService()
+    try:
+        response = service.fetch_association(request.gene, request.disease)
+    except Exception as e:
+        return error(f"Service error: {str(e)}", status_code=500)
+    saved = save_user_query(
+        user_id=user.id,
+        gene=request.gene,
+        disease=request.disease,
+        response=response,
+    )
+    return success(
+        "Query executed successfully",
+        {
+            "id": saved.id,
+            "gene": saved.gene,
+            "disease": saved.disease,
+            "response": response,
+            "created_at": saved.created_at.isoformat(),
+        },
+    )
+
+
+@app.get("/queries/{username}")
+def list_user_queries(username: str):
+    user = get_user_by_name(username)
+    if not user:
+        return error("User not found", status_code=404)
+    queries = get_user_queries(user.id)
+    return success(
+        "User queries retrieved",
+        [
+            {
+                "id": q.id,
+                "gene": q.gene,
+                "disease": q.disease,
+                "response": q.service_response,
+                "created_at": q.created_at.isoformat(),
+            }
+            for q in queries
+        ],
     )

--- a/src/geneva/services/base.py
+++ b/src/geneva/services/base.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class GeneDiseaseService(ABC):
+
+    @abstractmethod
+    def fetch_association(
+        self, gene_name: str, disease_name: str
+    ) -> Dict[str, Any]:
+        """
+        Fetch gene-disease association for the given gene and disease names.
+        Must return a JSON-serializable dict with relevant fields.
+        """
+        pass

--- a/src/geneva/services/opentarget.py
+++ b/src/geneva/services/opentarget.py
@@ -1,0 +1,39 @@
+import httpx
+
+from geneva.services.base import GeneDiseaseService
+from geneva.services.opentarget_config import BASE_URL, QUERIES
+
+
+class OpenTargetService(GeneDiseaseService):
+
+    def _run_query(self, query: str, variables: dict) -> dict:
+        with httpx.Client() as client:
+            response = client.post(
+                BASE_URL, json={"query": query, "variables": variables}
+            )
+            response.raise_for_status()
+            return response.json()
+
+    def _resolve_gene_id(self, gene_name: str) -> str:
+        hits = self._run_query(QUERIES.gene, {"queryString": gene_name})[
+            "data"
+        ]["search"]["hits"]
+        if not hits:
+            raise ValueError(f"No gene found for {gene_name}")
+        return hits[0]["id"]
+
+    def _resolve_disease_id(self, disease_name: str) -> str:
+        hits = self._run_query(QUERIES.disease, {"queryString": disease_name})[
+            "data"
+        ]["search"]["hits"]
+        if not hits:
+            raise ValueError(f"No disease found for {disease_name}")
+        return hits[0]["id"]
+
+    def fetch_association(self, gene_name: str, disease_name: str) -> dict:
+        gene_id = self._resolve_gene_id(gene_name)
+        disease_id = self._resolve_disease_id(disease_name)
+        return self._run_query(
+            QUERIES.target_disease,
+            {"geneId": gene_id, "diseaseId": disease_id},
+        )["data"]["disease"]

--- a/src/geneva/services/opentarget_config.py
+++ b/src/geneva/services/opentarget_config.py
@@ -1,0 +1,55 @@
+# flake8: noqa
+from dataclasses import dataclass
+
+BASE_URL = "https://api.platform.opentargets.org/api/v4/graphql"
+
+
+@dataclass(frozen=True)
+class Queries:
+    gene: str
+    disease: str
+    target_disease: str
+
+
+QUERIES = Queries(
+    gene="""
+    query findTarget($queryString: String!) {
+      search(queryString: $queryString, entityNames: ["target"], page: { index: 0, size: 1 }) {
+        hits { id }
+      }
+    }
+    """,
+    disease="""
+    query findDisease($queryString: String!) {
+      search(queryString: $queryString, entityNames: ["disease"], page: { index: 0, size: 1 }) {
+        hits { id }
+      }
+    }
+    """,
+    target_disease="""
+    query targetDiseaseEvidence($diseaseId: String!, $geneId: String!) {
+      disease(efoId: $diseaseId) {
+        id
+        name
+        evidences(ensemblIds: [$geneId]) {
+          count
+          rows {
+            disease { id name }
+            diseaseFromSource
+            target { id approvedSymbol }
+            mutatedSamples {
+              functionalConsequence { id label }
+              numberSamplesTested
+              numberMutatedSamples
+            }
+            resourceScore
+            significantDriverMethods
+            cohortId
+            cohortShortName
+            cohortDescription
+          }
+        }
+      }
+    }
+    """,
+)

--- a/tests/geneva/services/test_opentarget.py
+++ b/tests/geneva/services/test_opentarget.py
@@ -1,0 +1,53 @@
+import pytest
+
+from geneva.services.opentarget import OpenTargetService
+from geneva.services.opentarget_config import QUERIES
+
+MOCK_GENE_RESPONSE = {"data": {"search": {"hits": [{"id": "ENSG000001"}]}}}
+MOCK_DISEASE_RESPONSE = {"data": {"search": {"hits": [{"id": "EFO_0001"}]}}}
+MOCK_ASSOCIATION_RESPONSE = {
+    "data": {
+        "disease": {
+            "id": "EFO_0001",
+            "name": "Cancer",
+            "evidences": {"count": 1, "rows": []},
+        }
+    }
+}
+
+
+@pytest.fixture
+def service():
+    return OpenTargetService()
+
+
+def test_resolve_gene_id(monkeypatch, service):
+    monkeypatch.setattr(service, "_run_query", lambda q, v: MOCK_GENE_RESPONSE)
+    gene_id = service._resolve_gene_id("TP53")
+    assert gene_id == "ENSG000001"
+
+
+def test_resolve_disease_id(monkeypatch, service):
+    monkeypatch.setattr(
+        service, "_run_query", lambda q, v: MOCK_DISEASE_RESPONSE
+    )
+    disease_id = service._resolve_disease_id("Cancer")
+    assert disease_id == "EFO_0001"
+
+
+def test_fetch_association(monkeypatch, service):
+    def mock_run_query(query, variables):
+        if query == QUERIES.gene:
+            return MOCK_GENE_RESPONSE
+        elif query == QUERIES.disease:
+            return MOCK_DISEASE_RESPONSE
+        elif query == QUERIES.target_disease:
+            return MOCK_ASSOCIATION_RESPONSE
+        raise ValueError("Unexpected query")
+
+    monkeypatch.setattr(service, "_run_query", mock_run_query)
+
+    result = service.fetch_association("TP53", "Cancer")
+    assert result["id"] == "EFO_0001"
+    assert result["name"] == "Cancer"
+    assert "evidences" in result


### PR DESCRIPTION
Adds OpenTargets service integration to GenEvA.

- Implements `OpenTargetService(GeneDiseaseService)`.
- `GeneDiseaseService` is an abstract base class defining the contract: any future gene–disease data service must implement `fetch_association(gene_name, disease_name)` and return a JSON-serializable dict.
- New POST `/query` endpoint for running gene–disease queries.
- New GET `/queries/{username}` endpoint to fetch user query history.
- Queries are saved in the database.
- Includes tests with mocked OpenTargets responses.
