### PR TITLE
Integrate OpenRouter LLM for gene-disease query analysis

### DIFF
--- a/src/geneva/model.py
+++ b/src/geneva/model.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -18,6 +19,7 @@ class UserQuery(SQLModel, table=True):
     gene: str
     disease: str
     service_response: str
+    llm_response: Optional[str] = None
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
@@ -47,16 +49,19 @@ def user_exists(username: str) -> bool:
 
 
 def save_user_query(
-    user_id: int, gene: str, disease: str, response: dict
+    user_id: int,
+    gene: str,
+    disease: str,
+    service_response: dict,
+    llm_response: Optional[dict] = None,
 ) -> UserQuery:
-    import json
-
     with Session(engine) as session:
         query = UserQuery(
             user_id=user_id,
             gene=gene,
             disease=disease,
-            service_response=json.dumps(response),
+            service_response=json.dumps(service_response),
+            llm_response=json.dumps(llm_response) if llm_response else None,
         )
         session.add(query)
         session.commit()

--- a/src/geneva/services/base.py
+++ b/src/geneva/services/base.py
@@ -13,3 +13,19 @@ class GeneDiseaseService(ABC):
         Must return a JSON-serializable dict with relevant fields.
         """
         pass
+
+
+class LLMService(ABC):
+
+    @abstractmethod
+    def summarize_gene_disease(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Take a gene-disease association dictionary (from GeneDiseaseService)
+        and return a JSON-serializable summary with cleaned information.
+
+        Expected output fields (example):
+            - summary_text: str
+            - key_findings: list[str]
+            - confidence: Optional[float]
+        """
+        pass

--- a/src/geneva/services/openrouter.py
+++ b/src/geneva/services/openrouter.py
@@ -1,0 +1,63 @@
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .base import LLMService
+from .openrouter_config import BASE_URL, MODEL_WITH_FORMAT, OpenRouterHeaders
+
+
+class OpenRouterService(LLMService):
+    def __init__(self, api_key: str, model_config=MODEL_WITH_FORMAT):
+        self.headers = OpenRouterHeaders(api_key=api_key).as_dict
+        self.model_config = model_config
+        self.base_url = BASE_URL
+        self.model_name = model_config.model_name
+
+    def _ask_model(self, prompt: str) -> str:
+        payload = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.model_config.max_tokens,
+            "temperature": self.model_config.temperature,
+        }
+
+        try:
+            with httpx.Client(timeout=30) as client:
+                response = client.post(
+                    self.base_url, headers=self.headers, json=payload
+                )
+                response.raise_for_status()
+                data = response.json()
+                return data["choices"][0]["message"]["content"].strip()
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    def summarize_gene_disease(
+        self, data: Dict[str, Any], additional_context: Optional[str] = None
+    ) -> Dict[str, Any]:
+        gene = data.get("gene", "Unknown")
+        disease = data.get("disease", "Unknown")
+
+        prompt = (
+            f"{self.model_config.system_prompt}\n\n"
+            f"Gene: {gene}\n"
+            f"Disease: {disease}\n"
+            f"Data: {json.dumps(data, indent=2)}"
+        )
+
+        if additional_context:
+            prompt += f"\n\nContext: {additional_context}"
+
+        response_text = self._ask_model(prompt)
+
+        try:
+            summary_json = json.loads(response_text)
+        except json.JSONDecodeError:
+            summary_json = {
+                "summary_text": response_text,
+                "key_findings": [],
+                "confidence": None,
+            }
+
+        return summary_json

--- a/src/geneva/services/openrouter_config.py
+++ b/src/geneva/services/openrouter_config.py
@@ -1,0 +1,51 @@
+# flake8: noqa
+from dataclasses import dataclass
+from typing import Optional
+
+BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+@dataclass
+class OpenRouterHeaders:
+    api_key: str
+    content_type: str = "application/json"
+
+    @property
+    def as_dict(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": self.content_type,
+        }
+
+
+@dataclass
+class ModelConfig:
+    model_name: str
+    max_tokens: int = 2000
+    temperature: float = 0.1
+    system_prompt: Optional[str] = None
+
+
+DEFAULT_MODEL = ModelConfig(
+    model_name="google/gemini-2.0-flash-001",
+    max_tokens=2000,
+    temperature=0.1,
+    system_prompt="You are a helpful assistant that summarizes gene-disease associations.",
+)
+
+MODEL_WITH_FORMAT = ModelConfig(
+    model_name="google/gemini-2.0-flash-001",
+    max_tokens=2000,
+    temperature=0.1,
+    system_prompt=(
+        "You are a helpful assistant that summarizes gene-disease associations. "
+        "You must strictly respond in the following JSON format:\n"
+        "{\n"
+        '  "summary_text": str,\n'
+        '  "key_findings": [str],\n'
+        '  "confidence": float (0.0 - 1.0, optional)\n'
+        "}\n"
+        "Do not include any extra text outside this JSON. "
+        "If any field is missing or unknown, use empty string or empty array or null."
+    ),
+)

--- a/tests/geneva/services/test_openrouter.py
+++ b/tests/geneva/services/test_openrouter.py
@@ -1,0 +1,93 @@
+import json
+
+import pytest
+
+from geneva.services.openrouter import OpenRouterService
+
+
+@pytest.fixture
+def api_key():
+    return "test-api-key"
+
+
+@pytest.fixture
+def service(api_key):
+    return OpenRouterService(api_key=api_key)
+
+
+class TestOpenRouterService:
+    def test_initialization(self, service):
+        assert service.model_name == "google/gemini-2.0-flash-001"
+        assert service.base_url is not None
+        assert "Authorization" in service.headers
+        assert "Content-Type" in service.headers
+
+    def test_summarize_gene_disease_with_valid_json(
+        self, service, monkeypatch
+    ):
+        sample_data = {
+            "gene": "TP53",
+            "disease": "Cancer",
+            "association_data": {"score": 0.95},
+        }
+        expected_output = {
+            "summary_text": "TP53 is strongly associated with Cancer.",
+            "key_findings": ["TP53 mutation linked to Cancer"],
+            "confidence": 0.95,
+        }
+
+        def mock_ask_model(prompt):
+            return json.dumps(expected_output)
+
+        monkeypatch.setattr(service, "_ask_model", mock_ask_model)
+
+        result = service.summarize_gene_disease(sample_data)
+        assert result == expected_output
+
+    def test_summarize_gene_disease_with_invalid_json(
+        self, service, monkeypatch
+    ):
+        sample_data = {
+            "gene": "BRCA1",
+            "disease": "Breast Cancer",
+            "association_data": {},
+        }
+
+        def mock_ask_model(prompt):
+            return "Oops, malformed response"
+
+        monkeypatch.setattr(service, "_ask_model", mock_ask_model)
+
+        result = service.summarize_gene_disease(sample_data)
+        assert "Oops, malformed response" in result["summary_text"]
+        assert result["key_findings"] == []
+        assert result["confidence"] is None
+
+    def test_summarize_gene_disease_with_additional_context(
+        self, service, monkeypatch
+    ):
+        sample_data = {"gene": "EGFR", "disease": "Lung Cancer"}
+        additional_context = "Consider latest research papers."
+
+        def mock_ask_model(prompt):
+            assert "Consider latest research papers." in prompt
+            return json.dumps(
+                {
+                    "summary_text": "EGFR associated with Lung Cancer.",
+                    "key_findings": [
+                        "EGFR mutation drives cancer progression"
+                    ],
+                    "confidence": 0.9,
+                }
+            )
+
+        monkeypatch.setattr(service, "_ask_model", mock_ask_model)
+
+        result = service.summarize_gene_disease(
+            sample_data, additional_context
+        )
+        assert result["summary_text"] == "EGFR associated with Lung Cancer."
+        assert result["key_findings"] == [
+            "EGFR mutation drives cancer progression"
+        ]
+        assert result["confidence"] == 0.9

--- a/tests/geneva/test_model.py
+++ b/tests/geneva/test_model.py
@@ -42,7 +42,7 @@ class TestUserModel:
 
 
 class TestUserQueryModel:
-    def test_save_and_get_user_query(self):
+    def test_save_and_get_user_query_without_llm(self):
         user = create_user("dave", "key001")
         response_data = {"some": "result", "value": 42}
         save_user_query(user.id, "TP53", "cancer", response_data)
@@ -54,12 +54,37 @@ class TestUserQueryModel:
         assert uq.gene == "TP53"
         assert uq.disease == "cancer"
         assert isinstance(uq.service_response, str)
-        # Optional: check that JSON can be loaded
+        assert uq.llm_response is None
         loaded = json.loads(uq.service_response)
         assert loaded == response_data
 
+    def test_save_and_get_user_query_with_llm(self):
+        user = create_user("frank", "key002")
+        service_response = {"score": 0.95}
+        llm_response = {
+            "summary_text": "TP53 is associated with cancer",
+            "key_findings": ["Mutation found in TP53 gene"],
+            "confidence": 0.95,
+        }
+
+        save_user_query(
+            user.id,
+            "TP53",
+            "cancer",
+            service_response,
+            llm_response=llm_response,
+        )
+
+        queries = get_user_queries(user.id)
+        assert len(queries) == 1
+        uq = queries[0]
+        loaded_service = json.loads(uq.service_response)
+        loaded_llm = json.loads(uq.llm_response)
+        assert loaded_service == service_response
+        assert loaded_llm == llm_response
+
     def test_timestamp_set(self):
-        user = create_user("eve", "key002")
+        user = create_user("eve", "key003")
         response_data = {"test": True}
         save_user_query(user.id, "BRCA1", "breast cancer", response_data)
 


### PR DESCRIPTION
- Added `OpenRouterService` to process gene-disease query results from OpenTarget.
- Updated `main.py` endpoints to include LLM analysis after OpenTarget lookup.
- Modified `model.py` to store LLM responses alongside service responses.
- Added tests for LLM integration and updated existing tests accordingly.
- Ensures queries return both raw and summarized insights from the LLM.
